### PR TITLE
OSOE-536: In NuGet publish workflow, restrict valid versions to vM.N.O or v.M.N.O-alpha.X.[issue-code]

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,6 @@ jobs:
       machine-types: "['ubuntu-22.04', 'windows-2022']"
       build-directory: NuGetTest
       timeout-minutes: 20
-      build-create-binary-log: "true"
 
   spelling:
     name: Spelling

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,7 @@ jobs:
       machine-types: "['ubuntu-22.04', 'windows-2022']"
       build-directory: NuGetTest
       timeout-minutes: 20
+      build-create-binary-log: "true"
 
   spelling:
     name: Spelling


### PR DESCRIPTION
[OSOE-536](https://lombiq.atlassian.net/browse/OSOE-536)

[OSOE-536]: https://lombiq.atlassian.net/browse/OSOE-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ