### PR TITLE
OSOE-635: Run Windows CI builds only just before merging PRs

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -57,7 +57,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-635
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -4,6 +4,7 @@ name: Build and Test Windows
 # because Windows builds are much slower and more expensive than Ubuntu ones, and them catching issues that aren't
 # surfaced under Ubuntu is rare (but does happen). So, not running them for every push of every PR.
 on:
+  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -62,3 +62,20 @@ jobs:
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}
       JIRA_API_TOKEN: ${{ secrets.DEFAULT_JIRA_API_TOKEN }}
       MERGE_TOKEN: ${{ secrets.LOMBIQBOT_GITHUB_PERSONAL_ACCESS_TOKEN }}
+
+  remove-windows-build-warning-label:
+    name: Remove Windows Build Warning Label
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    if: ${{ always() }}
+    needs: [post-pull-request-checks-automation]
+    steps:
+    - name: Remove Windows Build Warning Label
+      # v2.0.0
+      uses: buildsville/add-remove-label@eeae411a9be2e173f2420e1644514edbecc4e835
+      with:
+        # The token is necessary to be able to remove the label even if the workflow is triggered by a pull request
+        # coming from a fork.
+        token: ${{ secrets.LOMBIQBOT_GITHUB_PERSONAL_ACCESS_TOKEN }}
+        labels: requires-windows-build
+        type: remove

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -4,7 +4,6 @@ name: Build and Test Windows
 # because Windows builds are much slower and more expensive than Ubuntu ones, and them catching issues that aren't
 # surfaced under Ubuntu is rare (but does happen). So, not running them for every push of every PR.
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -41,7 +41,7 @@ jobs:
     name: Build and Test Windows - NuGetTest solution
     uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
-      machine-types: "[ 'windows-2022']"
+      machine-types: "['windows-2022']"
       build-directory: NuGetTest
       timeout-minutes: 20
       blame-hang-timeout: "5m"

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -56,7 +56,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-635
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -45,9 +45,16 @@ jobs:
       timeout-minutes: 20
       blame-hang-timeout: "5m"
 
+  powershell-static-code-analysis:
+    name: PowerShell Static Code Analysis
+    uses: Lombiq/PowerShell-Analyzers/.github/workflows/static-code-analysis.yml@dev
+    with:
+      machine-types: "['windows-2022']"
+      run-windows-powershell: "false"
+
   post-pull-request-checks-automation:
     name: Post Pull Request Checks Automation
-    needs: [build-and-test-larger-runners, build-and-test-nuget-test]
+    needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     if: github.event.pull_request != ''
     uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -1,8 +1,8 @@
 name: Build and Test Windows
 
-# Windows builds are only run on-demand, enforced to be run once before merging a PR, and for pushes to dev. This is
-# because Windows builds are much slower and more expensive than Ubuntu ones, and them catching issues that aren't
-# surfaced under Ubuntu is rare (but does happen). So, not running them for every push of every PR.
+# Windows builds are only run on-demand, to be run once before merging a PR, and for pushes to dev. This is because
+# Windows builds are much slower and more expensive than Ubuntu ones, and them catching issues that aren't surfaced
+# under Ubuntu is rare (but does happen). So, not running them for every push of every PR.
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -1,8 +1,10 @@
-name: Build and Test
+name: Build and Test Windows
 
-# Runs for PRs opened for any branch, and pushes to the dev branch.
+# Windows builds are only run on-demand, enforced to be run once before merging a PR, and for pushes to dev. This is
+# because Windows builds are much slower and more expensive than Ubuntu ones, and them catching issues that aren't
+# surfaced under Ubuntu is rare (but does happen). So, not running them for every push of every PR.
 on:
-  pull_request:
+  workflow_dispatch:
   push:
     branches:
       - dev
@@ -10,11 +12,11 @@ on:
 jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
-    name: Build and Test - root solution (larger runners)
+    name: Build and Test Windows - root solution (larger runners)
     uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
-      machine-types: "['gitrunners-ubuntu-2204-x64-4vcpu']"
-      timeout-minutes: 20
+      machine-types: "['gitrunners-windows-2022-x64-8vcpu']"
+      timeout-minutes: 30
       set-up-sql-server: "true"
       set-up-azurite: "true"
       ui-test-parallelism: 0
@@ -24,47 +26,28 @@ jobs:
   build-and-test-standard-runners:
     # Since dev builds are not awaited by anyone, they can run on the slower free runners.
     if: github.ref_name == github.event.repository.default_branch
-    name: Build and Test - root solution (standard runners)
+    name: Build and Test Windows - root solution (standard runners)
     uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
-      timeout-minutes: 30
+      machine-types: "['windows-2022']"
+      timeout-minutes: 60
       set-up-sql-server: "true"
       set-up-azurite: "true"
       build-create-binary-log: "true"
       blame-hang-timeout: "5m"
 
   build-and-test-nuget-test:
-    name: Build and Test - NuGetTest solution
+    name: Build and Test Windows - NuGetTest solution
     uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
+      machine-types: "[ 'windows-2022']"
       build-directory: NuGetTest
-      timeout-minutes: 10
+      timeout-minutes: 20
       blame-hang-timeout: "5m"
-
-  spelling:
-    name: Spelling
-    uses: Lombiq/GitHub-Actions/.github/workflows/spelling.yml@dev
-    with:
-      additional-dictionaries: |
-        cspell:csharp/csharp.txt
-        cspell:css/css.txt
-        cspell:fullstack/fullstack.txt
-        cspell:html/html.txt
-        cspell:node/node.txt
-        cspell:npm/npm.txt
-        lombiq-lgha:dictionaries/Liquid.txt
-        lombiq-lgha:dictionaries/Xml.txt
-        lombiq-lgha:dictionaries/Lombiq.people.txt
-
-  powershell-static-code-analysis:
-    name: PowerShell Static Code Analysis
-    uses: Lombiq/PowerShell-Analyzers/.github/workflows/static-code-analysis.yml@dev
-    with:
-      run-windows-powershell: "false"
 
   post-pull-request-checks-automation:
     name: Post Pull Request Checks Automation
-    needs: [build-and-test-larger-runners, build-and-test-nuget-test, spelling]
+    needs: [build-and-test-larger-runners, build-and-test-nuget-test]
     if: github.event.pull_request != ''
     uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -4,7 +4,6 @@ name: Build and Test Windows
 # Windows builds are much slower and more expensive than Ubuntu ones, and them catching issues that aren't surfaced
 # under Ubuntu is rare (but does happen). So, not running them for every push of every PR.
 on:
-  pull_request:
   workflow_dispatch:
   push:
     branches:

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -47,7 +47,7 @@ jobs:
       blame-hang-timeout: "5m"
 
   powershell-static-code-analysis:
-    name: PowerShell Static Code Analysis
+    name: PowerShell Static Code Analysis Windows
     uses: Lombiq/PowerShell-Analyzers/.github/workflows/static-code-analysis.yml@dev
     with:
       machine-types: "['windows-2022']"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
     name: PowerShell Static Code Analysis
     uses: Lombiq/PowerShell-Analyzers/.github/workflows/static-code-analysis.yml@dev
     with:
-      run-windows-powershell: "false"
+      machine-types: "['ubuntu-22.04']"
 
   post-pull-request-checks-automation:
     name: Post Pull Request Checks Automation

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, spelling, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-635
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
 
   post-pull-request-checks-automation:
     name: Post Pull Request Checks Automation
-    needs: [build-and-test-larger-runners, build-and-test-nuget-test, spelling]
+    needs: [build-and-test-larger-runners, build-and-test-nuget-test, spelling, powershell-static-code-analysis]
     if: github.event.pull_request != ''
     uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, spelling, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-635
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,3 +72,20 @@ jobs:
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}
       JIRA_API_TOKEN: ${{ secrets.DEFAULT_JIRA_API_TOKEN }}
       MERGE_TOKEN: ${{ secrets.LOMBIQBOT_GITHUB_PERSONAL_ACCESS_TOKEN }}
+
+  add-windows-build-warning-label:
+    name: Add Windows Build Warning Label
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    if: ${{ always() }}
+    needs: [post-pull-request-checks-automation]
+    steps:
+    - name: Add Windows Build Warning Label
+      # v2.0.0
+      uses: buildsville/add-remove-label@eeae411a9be2e173f2420e1644514edbecc4e835
+      with:
+        # The token is necessary to be able to add the label even if the workflow is triggered by a pull request coming
+        # from a fork.
+        token: ${{ secrets.LOMBIQBOT_GITHUB_PERSONAL_ACCESS_TOKEN }}
+        labels: requires-windows-build
+        type: add

--- a/Lombiq.OSOCE.sln
+++ b/Lombiq.OSOCE.sln
@@ -135,6 +135,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lombiq.Privacy.Samples", "s
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{40E6EA88-BE15-4542-BD9A-3AA8DC69629E}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build-and-test-windows.yml = .github\workflows\build-and-test-windows.yml
 		.github\workflows\build-and-test.yml = .github\workflows\build-and-test.yml
 		.github\workflows\create-jira-issues-for-community-activities.yml = .github\workflows\create-jira-issues-for-community-activities.yml
 		.github\workflows\validate-pull-request.yml = .github\workflows\validate-pull-request.yml


### PR DESCRIPTION
[OSOE-635](https://lombiq.atlassian.net/browse/OSOE-635)
Fixes #481

[OSOE-635]: https://lombiq.atlassian.net/browse/OSOE-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ