### PR TITLE
OSOE-668: "Creating the web driver failed" exception recently on GitHub-hosted Linux runners for Edge in Lombiq.UITestingToolbox

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -22,6 +22,7 @@ Timestamped
 Toolset
 uncached
 unclickable
+VSTHRD
 Wxga
 yuv
 ZXing


### PR DESCRIPTION
[OSOE-668](https://lombiq.atlassian.net/browse/OSOE-668)

[OSOE-668]: https://lombiq.atlassian.net/browse/OSOE-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ