### PR TITLE
OSOE-636: Fixing check-spelling update to v0.0.22 in Lombiq.GitHub.Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-636
     with:
       machine-types: "['gitrunners-ubuntu-2204-x64-4vcpu']"
       timeout-minutes: 20
@@ -35,7 +35,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-636
     with:
       build-directory: NuGetTest
       timeout-minutes: 15

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
 
   spelling:
     name: Spelling
-    uses: Lombiq/GitHub-Actions/.github/workflows/spelling.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/spelling.yml@issue/OSOE-636
     with:
       additional-dictionaries: |
         cspell:csharp/csharp.txt

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,7 +47,7 @@ jobs:
     with:
       additional-dictionaries: |
         cspell:csharp/csharp.txt
-        css/dict/css.txt
+        cspell:css/dict/css.txt
         cspell:fullstack/dict/fullstack.txt
         cspell:html-symbol-entities/entities.txt
         cspell:html/dict/html.txt

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,11 +47,13 @@ jobs:
     with:
       additional-dictionaries: |
         cspell:csharp/csharp.txt
-        cspell:css/css.txt
-        cspell:fullstack/fullstack.txt
-        cspell:html/html.txt
-        cspell:node/node.txt
-        cspell:npm/npm.txt
+        css/dict/css.txt
+        cspell:fullstack/dict/fullstack.txt
+        cspell:html-symbol-entities/entities.txt
+        cspell:html/dict/html.txt
+        cspell:html/src/svg.txt
+        cspell:node/dict/node.txt
+        cspell:npm/dict/npm.txt
         lombiq-lgha:dictionaries/Liquid.txt
         lombiq-lgha:dictionaries/Xml.txt
         lombiq-lgha:dictionaries/Lombiq.people.txt

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-636
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       machine-types: "['gitrunners-ubuntu-2204-x64-4vcpu']"
       timeout-minutes: 20
@@ -35,7 +35,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-636
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       build-directory: NuGetTest
       timeout-minutes: 15
@@ -43,7 +43,7 @@ jobs:
 
   spelling:
     name: Spelling
-    uses: Lombiq/GitHub-Actions/.github/workflows/spelling.yml@issue/OSOE-636
+    uses: Lombiq/GitHub-Actions/.github/workflows/spelling.yml@dev
     with:
       additional-dictionaries: |
         cspell:csharp/csharp.txt

--- a/test/Lombiq.OSOCE.Tests.UI/UITestBase.cs
+++ b/test/Lombiq.OSOCE.Tests.UI/UITestBase.cs
@@ -13,7 +13,8 @@ namespace Lombiq.OSOCE.Tests.UI;
 public abstract class UITestBase : OrchardCoreUITestBase<Program>
 {
     protected UITestBase(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper) {
+        : base(testOutputHelper)
+    {
     }
 
     protected override Task ExecuteTestAfterSetupAsync(

--- a/test/Lombiq.OSOCE.Tests.UI/UITestBase.cs
+++ b/test/Lombiq.OSOCE.Tests.UI/UITestBase.cs
@@ -13,8 +13,7 @@ namespace Lombiq.OSOCE.Tests.UI;
 public abstract class UITestBase : OrchardCoreUITestBase<Program>
 {
     protected UITestBase(ITestOutputHelper testOutputHelper)
-        : base(testOutputHelper)
-    {
+        : base(testOutputHelper) {
     }
 
     protected override Task ExecuteTestAfterSetupAsync(


### PR DESCRIPTION
[OSOE-636](https://lombiq.atlassian.net/browse/OSOE-636)

[OSOE-636]: https://lombiq.atlassian.net/browse/OSOE-636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ