### PR TITLE
OSOE-689: update-github-issue-and-pull-request action shouldn't fail when issues are disabled in Lombiq.GitHub.Actions

### DIFF
--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   validate-pull-request:
     name: Validate Pull Request
-    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@issue/OSOE-689


### PR DESCRIPTION
[OSOE-689](https://lombiq.atlassian.net/browse/OSOE-689)

[OSOE-689]: https://lombiq.atlassian.net/browse/OSOE-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ