### PR TITLE
OSOE-51: Deleting leftover package-lock files.

### DIFF
--- a/NuGetTest/src/Themes/Lombiq.OSOCE.NuGet.TestTheme/package-lock.json
+++ b/NuGetTest/src/Themes/Lombiq.OSOCE.NuGet.TestTheme/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Lombiq.OSOCE.NuGet.TestTheme",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
[OSOE-51](https://lombiq.atlassian.net/browse/OSOE-51)

[OSOE-51]: https://lombiq.atlassian.net/browse/OSOE-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ