### PR TITLE
revert-235: OSOE-464:  Executing dotnet test with process timeout

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.ref_name != github.event.repository.default_branch &&
         (github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-windows-build')
     name: Build and Test Windows - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
     with:
       parent-job-name: "root-solution-larger-runners"
       machine-types: "['gitrunners-windows-2022-x64-8vcpu']"
@@ -51,7 +51,7 @@ jobs:
     # Since dev builds are not awaited by anyone, they can run on the slower free runners.
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test Windows - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
     with:
       parent-job-name: "root-solution-standard-runners"
       machine-types: "['windows-2022']"
@@ -69,7 +69,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         github.event.label.name == 'run-windows-build'
     name: Build and Test Windows - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
     with:
       parent-job-name: "nuget-solution"
       machine-types: "['windows-2022']"

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -33,7 +33,7 @@ jobs:
     if: github.ref_name != github.event.repository.default_branch &&
         (github.event_name == 'workflow_dispatch' || github.event.label.name == 'run-windows-build')
     name: Build and Test Windows - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: "root-solution-larger-runners"
       machine-types: "['gitrunners-windows-2022-x64-8vcpu']"
@@ -51,7 +51,7 @@ jobs:
     # Since dev builds are not awaited by anyone, they can run on the slower free runners.
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test Windows - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: "root-solution-standard-runners"
       machine-types: "['windows-2022']"
@@ -69,7 +69,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         github.event.label.name == 'run-windows-build'
     name: Build and Test Windows - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: "nuget-solution"
       machine-types: "['windows-2022']"

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -42,7 +42,7 @@ jobs:
       set-up-azurite: "true"
       ui-test-parallelism: 0
       build-create-binary-log: "true"
-      dotnet-test-process-timeout: 360000
+      blame-hang-timeout: "5m"
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: "FullyQualifiedName!~SecurityScanningTests"
@@ -59,7 +59,7 @@ jobs:
       set-up-sql-server: "true"
       set-up-azurite: "true"
       build-create-binary-log: "true"
-      dotnet-test-process-timeout: 360000
+      blame-hang-timeout: "5m"
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: "FullyQualifiedName!~SecurityScanningTests"
@@ -75,7 +75,7 @@ jobs:
       machine-types: "['windows-2022']"
       build-directory: NuGetTest
       timeout-minutes: 25
-      dotnet-test-process-timeout: 360000
+      blame-hang-timeout: "5m"
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: "FullyQualifiedName!~SecurityScanningTests"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
     with:
       parent-job-name: "root-solution-larger-runners"
       machine-types: "['buildjet-4vcpu-ubuntu-2204']"
@@ -28,7 +28,7 @@ jobs:
     # Since dev builds are not awaited by anyone, they can run on the slower free runners.
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
     with:
       parent-job-name: "root-solution-standard-runners"
       timeout-minutes: 40
@@ -39,7 +39,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
     with:
       parent-job-name: "nuget-solution"
       build-directory: NuGetTest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
       set-up-azurite: "true"
       ui-test-parallelism: 0
       build-create-binary-log: "true"
-      dotnet-test-process-timeout: 360000
+      blame-hang-timeout: "5m"
       build-enable-nuget-caching: "true"
       build-enable-npm-caching: "true"
 
@@ -35,7 +35,7 @@ jobs:
       set-up-sql-server: "true"
       set-up-azurite: "true"
       build-create-binary-log: "true"
-      dotnet-test-process-timeout: 360000
+      blame-hang-timeout: "5m"
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
@@ -44,7 +44,7 @@ jobs:
       parent-job-name: "nuget-solution"
       build-directory: NuGetTest
       timeout-minutes: 15
-      dotnet-test-process-timeout: 360000
+      blame-hang-timeout: "5m"
 
   spelling:
     name: Spelling

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: "root-solution-larger-runners"
       machine-types: "['buildjet-4vcpu-ubuntu-2204']"
@@ -28,7 +28,7 @@ jobs:
     # Since dev builds are not awaited by anyone, they can run on the slower free runners.
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: "root-solution-standard-runners"
       timeout-minutes: 40
@@ -39,7 +39,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@revert-235-issue/OSOE-464-executing-dotnet-test-with-process-timeout
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: "nuget-solution"
       build-directory: NuGetTest


### PR DESCRIPTION
[revert-486](https://lombiq.atlassian.net/browse/revert-486)
Reverts Lombiq/Open-Source-Orchard-Core-Extensions#486