### PR TITLE
OSOE-834: Remove `build-create-binary-log` and `dotnet-test-process-timeout` configurations from OSOCE workflows

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -44,8 +44,6 @@ jobs:
       set-up-sql-server: "true"
       set-up-azurite: "true"
       ui-test-parallelism: 0
-      build-create-binary-log: "true"
-      dotnet-test-process-timeout: 720000
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: "FullyQualifiedName!~SecurityScanningTests"
@@ -61,8 +59,6 @@ jobs:
       timeout-minutes: 70
       set-up-sql-server: "true"
       set-up-azurite: "true"
-      build-create-binary-log: "true"
-      dotnet-test-process-timeout: 840000
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: "FullyQualifiedName!~SecurityScanningTests"
@@ -79,7 +75,6 @@ jobs:
       machine-types: "['windows-2022']"
       build-directory: NuGetTest
       timeout-minutes: 30
-      dotnet-test-process-timeout: 540000
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: "FullyQualifiedName!~SecurityScanningTests"

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -57,8 +57,8 @@ jobs:
       # Since dev builds are not awaited by anyone, they can run on the slower free runners.
       machine-types: "['windows-2022']"
       timeout-minutes: 70
-      set-up-sql-server: "true"
-      set-up-azurite: "true"
+      set-up-sql-server: 'true'
+      set-up-azurite: 'true'
       # Running ZAP for security scans in Docker under GHA Windows runners won't work since such virtualization is not
       # supported by GHA.
       test-filter: FullyQualifiedName!~SecurityScanningTests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     with:
       parent-job-name: "root-solution-larger-runners"
       machine-types: "['warp-ubuntu-2204-x64-4x']"
-      timeout-minutes: 30
+      timeout-minutes: 60
       set-up-sql-server: "true"
       set-up-azurite: "true"
       ui-test-parallelism: 0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,8 +19,6 @@ jobs:
       set-up-sql-server: "true"
       set-up-azurite: "true"
       ui-test-parallelism: 0
-      build-create-binary-log: "true"
-      dotnet-test-process-timeout: 600000
       build-enable-nuget-caching: "true"
       build-enable-npm-caching: "true"
 
@@ -34,8 +32,6 @@ jobs:
       timeout-minutes: 50
       set-up-sql-server: "true"
       set-up-azurite: "true"
-      build-create-binary-log: "true"
-      dotnet-test-process-timeout: 780000
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
@@ -44,7 +40,6 @@ jobs:
       parent-job-name: nuget-solution
       build-directory: NuGetTest
       timeout-minutes: 20
-      dotnet-test-process-timeout: 480000
 
   spelling:
     name: Spelling

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,8 +30,8 @@ jobs:
       # Since dev builds are not awaited by anyone, they can run on the slower free runners.
       parent-job-name: root-solution-standard-runners
       timeout-minutes: 50
-      set-up-sql-server: "true"
-      set-up-azurite: "true"
+      set-up-sql-server: 'true'
+      set-up-azurite: 'true'
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution


### PR DESCRIPTION
[OSOE-834](https://lombiq.atlassian.net/browse/OSOE-834)
fixes #736 

[OSOE-834]: https://lombiq.atlassian.net/browse/OSOE-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ