### PR TITLE
OSOE-589: Shape Tracing should skip the PageTitle shape in Lombiq.HelpfulExtensions

### DIFF
--- a/src/Lombiq.OSOCE.Web/Recipes/Lombiq.OSOCE.Tests.recipe.json
+++ b/src/Lombiq.OSOCE.Web/Recipes/Lombiq.OSOCE.Tests.recipe.json
@@ -24,9 +24,7 @@
         "Lombiq.HelpfulExtensions.CodeGeneration",
         "Lombiq.HelpfulExtensions.ContentTypes",
         "Lombiq.HelpfulExtensions.Flows",
-        // Shape Tracing messes with the title and thus can break other things, see:
-        // https://github.com/Lombiq/Helpful-Extensions/issues/120.
-        // "Lombiq.HelpfulExtensions.ShapeTracing",
+        "Lombiq.HelpfulExtensions.ShapeTracing",
         "Lombiq.HelpfulExtensions.Widgets",
         "Lombiq.HelpfulLibraries.Samples",
         "Lombiq.Hosting.BuildVersionDisplay",


### PR DESCRIPTION
[OSOE-589](https://lombiq.atlassian.net/browse/OSOE-589)

[OSOE-589]: https://lombiq.atlassian.net/browse/OSOE-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ