### PR TITLE
OSOE-888: Fix that `eps1lon/actions-label-merge-conflict` uses outdated Node.js 16 in Lombiq.GitHub.Actions

### DIFF
--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -2,7 +2,7 @@ name: Validate Pull Request
 
 on:
   push:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   validate-pull-request:
     name: Validate Pull Request
-    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@issue/OSOE-888

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -2,7 +2,7 @@ name: Validate Pull Request
 
 on:
   push:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
[OSOE-888](https://lombiq.atlassian.net/browse/OSOE-888)

[OSOE-888]: https://lombiq.atlassian.net/browse/OSOE-888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ