### PR TITLE
LMBQ-429: Adding the ability to maintain more than one Cloudflare IP Access Rule for remote tests in Lombiq.UITestingToolbox

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -50,6 +50,7 @@ jobs:
       # The currently used Elasticsearch setup action (https://github.com/elastic/elastic-github-actions/tree/master/elasticsearch)
       # can only be used on Linux.
       test-filter: FullyQualifiedName!~SecurityScanningTests&FullyQualifiedName!~BehaviorElasticsearchTests
+      cancel-in-progress-for-this-pr: 'false'
 
   build-and-test-standard-runners:
     if: github.ref_name == github.event.repository.default_branch
@@ -91,6 +92,7 @@ jobs:
       # every value being the same as with quotes.
       # yamllint disable-line rule:quoted-strings
       test-filter: 'FullyQualifiedName!~SecurityScanningTests&FullyQualifiedName!~BehaviorElasticsearchTests'
+      cancel-in-progress-for-this-pr: 'false'
 
   powershell-static-code-analysis:
     if: github.ref_name == github.event.repository.default_branch ||

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,7 @@ jobs:
       dotnet-test-process-timeout: 600000
       build-enable-nuget-caching: 'true'
       build-enable-npm-caching: 'true'
+      cancel-in-progress-for-this-pr: 'false'
 
   build-and-test-standard-runners:
     if: github.ref_name == github.event.repository.default_branch
@@ -46,6 +47,7 @@ jobs:
       build-directory: NuGetTest
       timeout-minutes: 20
       dotnet-test-process-timeout: 480000
+      cancel-in-progress-for-this-pr: 'false'
 
   spelling:
     name: Spelling


### PR DESCRIPTION
[LMBQ-429](https://lombiq.atlassian.net/browse/LMBQ-429)

[LMBQ-429]: https://lombiq.atlassian.net/browse/LMBQ-429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ