### PR TITLE
OSOE-404: Update datatables npm packages to supported versions, remove Assets workaround in Lombiq.DataTables

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -5,6 +5,5 @@ Assets/Vendors/
 ^\Qtest/Lombiq.UITestingToolbox/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/\E.*.yml$
 ^\Qtest/Lombiq.UITestingToolbox/Lombiq.Tests.UI.Samples/Tests/CustomZapAutomationFrameworkPlan.yml\E$
 ^\Qtools/Lombiq.GitHub.Actions/\E
-\QUnmanagedNodeModules/\E
 \QUploadingTestFileDOCX.docx\E$
 \QUploadingTestFileXLSX.xlsx\E$


### PR DESCRIPTION
[OSOE-404](https://lombiq.atlassian.net/browse/OSOE-404)

[OSOE-404]: https://lombiq.atlassian.net/browse/OSOE-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ