### PR TITLE
OSOE-1001: Enabling corepack before the build causes issues with non-NuGet builds too, so disabling it by default

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -97,9 +97,6 @@ jobs:
       # every value being the same as with quotes.
       # yamllint disable-line rule:quoted-strings
       test-filter: 'FullyQualifiedName!~SecurityScanningTests&FullyQualifiedName!~BehaviorElasticsearchTests'
-      # Corepack is enabled by Node.js Extensions anyway. For some reason, when NE is used from NuGet, its workaround
-      # for https://github.com/nodejs/corepack/issues/612 doesn't get applied.
-      enable-corepack: 'false'
 
   powershell-static-code-analysis:
     if: github.ref_name == github.event.repository.default_branch ||

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -36,7 +36,7 @@ jobs:
             github.event.label.name == 'run-windows-build' ||
             (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build')))
     name: Build and Test Windows - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1001
     with:
       parent-job-name: root-solution-larger-runners
       machine-types: '["windows-2022-8core"]'
@@ -80,7 +80,7 @@ jobs:
         github.event.label.name == 'run-windows-build' ||
         (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build'))
     name: Build and Test Windows - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1001
     with:
       parent-job-name: nuget-solution
       machine-types: '["windows-2022"]'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1001
     with:
       parent-job-name: root-solution-larger-runners
       machine-types: '["warp-ubuntu-2404-x64-4x"]'
@@ -44,7 +44,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1001
     with:
       parent-job-name: nuget-solution
       build-directory: NuGetTest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,9 +52,6 @@ jobs:
       # This way, we can see Node.js build issues in the build log.
       build-verbosity: minimal
       dotnet-test-process-timeout: 480000
-      # Corepack is enabled by Node.js Extensions anyway. For some reason, when NE is used from NuGet, its workaround
-      # for https://github.com/nodejs/corepack/issues/612 doesn't get applied.
-      enable-corepack: 'false'
 
 
   spelling:


### PR DESCRIPTION
[OSOE-1001](https://lombiq.atlassian.net/browse/OSOE-1001)

[OSOE-1001]: https://lombiq.atlassian.net/browse/OSOE-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ