### PR TITLE
OSOE-935: Fixing Orchard Core Media operations test in Lombiq.UITestingToolbox

### DIFF
--- a/NuGetTest/src/Lombiq.OSOCE.NuGet.Web/Lombiq.OSOCE.NuGet.Web.csproj
+++ b/NuGetTest/src/Lombiq.OSOCE.NuGet.Web/Lombiq.OSOCE.NuGet.Web.csproj
@@ -48,8 +48,8 @@
     <PackageReference Include="Lombiq.Privacy" Version="10.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.Privacy.Samples" Version="10.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.SetupExtensions" Version="7.0.0" />
-    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="12.1.1-alpha.3.osoe-935" />
-    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="12.1.1-alpha.3.osoe-935" />
+    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="12.1.1-alpha.5.osoe-935" />
+    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="12.1.1-alpha.5.osoe-935" />
     <PackageReference Include="Lombiq.UIKit" Version="9.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.VueJs" Version="8.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.VueJs.Samples" Version="8.0.1-alpha.0.osoe-935" />

--- a/NuGetTest/test/Lombiq.OSOCE.NuGet.Tests.UI/Lombiq.OSOCE.NuGet.Tests.UI.csproj
+++ b/NuGetTest/test/Lombiq.OSOCE.NuGet.Tests.UI/Lombiq.OSOCE.NuGet.Tests.UI.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Lombiq.OrchardCoreApiClient.Tests.UI" Version="7.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.Privacy.Tests.UI" Version="10.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.HelpfulExtensions.Tests.UI" Version="10.0.1-alpha.6.osoe-935" />
-    <PackageReference Include="Lombiq.Tests.UI" Version="12.1.1-alpha.3.osoe-935" />
+    <PackageReference Include="Lombiq.Tests.UI" Version="12.1.1-alpha.5.osoe-935" />
     <PackageReference Include="Lombiq.VueJs.Tests.UI" Version="8.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.Walkthroughs.Tests.UI" Version="3.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />


### PR DESCRIPTION
[OSOE-935](https://lombiq.atlassian.net/browse/OSOE-935)
Submodule test/Lombiq.UITestingToolbox:
    > 4450f5c1 - Fixing Orchard Core Media operations test
    > 9611b519 - Fixing that the WebDriver being closed upon an exception coming from the test could cause further exceptions when saving the test dump

[OSOE-935]: https://lombiq.atlassian.net/browse/OSOE-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ