### PR TITLE
NEST-649: DRY Google Fonts subresource integrity check and reCAPTCH-related false positives disable during security scans in Lombiq.UITestingToolbox

### DIFF
--- a/NuGetTest/src/Lombiq.OSOCE.NuGet.Web/Lombiq.OSOCE.NuGet.Web.csproj
+++ b/NuGetTest/src/Lombiq.OSOCE.NuGet.Web/Lombiq.OSOCE.NuGet.Web.csproj
@@ -53,8 +53,8 @@
     <PackageReference Include="Lombiq.Privacy" Version="10.0.1-alpha.4.osoe-1069" />
     <PackageReference Include="Lombiq.Privacy.Samples" Version="10.0.1-alpha.4.osoe-1069" />
     <PackageReference Include="Lombiq.SetupExtensions" Version="7.0.0" />
-    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="14.2.1-alpha.1.osoe-1223" />
-    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="14.2.1-alpha.1.osoe-1223" />
+    <PackageReference Include="Lombiq.Tests.UI.AppExtensions" Version="14.2.1-alpha.2.nest-649" />
+    <PackageReference Include="Lombiq.Tests.UI.Shortcuts" Version="14.2.1-alpha.2.nest-649" />
     <PackageReference Include="Lombiq.UIKit" Version="10.0.1-alpha.5.nest-643" />
     <PackageReference Include="Lombiq.UIKit.Widgets" Version="10.0.1-alpha.5.nest-643" />
     <PackageReference Include="Lombiq.UIKit.Widgets.Tests.UI" Version="10.0.1-alpha.5.nest-643" />

--- a/NuGetTest/test/Lombiq.OSOCE.NuGet.Tests.UI/Lombiq.OSOCE.NuGet.Tests.UI.csproj
+++ b/NuGetTest/test/Lombiq.OSOCE.NuGet.Tests.UI/Lombiq.OSOCE.NuGet.Tests.UI.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Lombiq.OrchardCoreApiClient.Tests.UI" Version="7.0.1-alpha.0.osoe-935" />
     <PackageReference Include="Lombiq.Privacy.Tests.UI" Version="10.0.1-alpha.4.osoe-1069" />
     <PackageReference Include="Lombiq.HelpfulExtensions.Tests.UI" Version="11.1.1-alpha.2.nest-643" />
-    <PackageReference Include="Lombiq.Tests.UI" Version="14.2.1-alpha.1.osoe-1223" />
+    <PackageReference Include="Lombiq.Tests.UI" Version="14.2.1-alpha.2.nest-649" />
     <PackageReference Include="Lombiq.UIKit.Widgets.Tests.UI" Version="10.0.1-alpha.5.nest-643" />
     <PackageReference Include="Lombiq.Walkthroughs.Tests.UI" Version="3.0.1-alpha.19.nest-643" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />


### PR DESCRIPTION
[NEST-649](https://lombiq.atlassian.net/browse/NEST-649)

[NEST-649]: https://lombiq.atlassian.net/browse/NEST-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ