### PR TITLE
OSOE-1282: Update dependencies: Meziantou.Analyzer 3.0.85→3.0.94, Elasticsearch 9.4.1→9.4.2, libman.json updates, digest pins

### DIFF
--- a/.agents/skills/renovate-integration/SKILL.md
+++ b/.agents/skills/renovate-integration/SKILL.md
@@ -116,10 +116,10 @@ Gate: proceed only after `APPROVED: Phase 2`
 Actions:
 - Push `issue/<WORK_ITEM_KEY>` branches to all repos that have one (submodules with multiple renovate branches or additional changes, and the superproject).
 - **Do not push or create PRs** for submodules where only a single renovate branch was checked out without further changes — their existing Renovate PRs are sufficient.
-- Open the **superproject PR first**, targeting `dev`, referencing `<WORK_ITEM_KEY>` in the PR title and description.
+- Open the **superproject PR first**, targeting `dev`, referencing `<WORK_ITEM_KEY>` in the PR description.
 - **Wait 60 seconds** after the superproject PR is created.
-- Then open PRs for the submodules that have `issue/<WORK_ITEM_KEY>` branches, targeting `dev`, referencing `<WORK_ITEM_KEY>`.
-- Submodule PR titles should reference the specific updates included, e.g. `Update dependencies: Microsoft.NET.Test.Sdk 18.0.1 → 18.3.0, Swashbuckle.AspNetCore 10.1.4 → 10.1.5`.
+- Then open PRs for the submodules that have `issue/<WORK_ITEM_KEY>` branches, targeting `dev`, referencing `<WORK_ITEM_KEY>` in the description.
+- PR titles should **not** include the issue key (it is added automatically from the branch name). Submodule PR titles should reference the specific updates included, e.g. `Update dependencies: Microsoft.NET.Test.Sdk 18.0.1 → 18.3.0, Swashbuckle.AspNetCore 10.1.4 → 10.1.5`.
 - After PRs are created, **wait for all CI workflow runs to complete**. Poll the run status periodically (e.g. every 60 seconds) using `gh run list`.
 - Once the Ubuntu build (Build and Test) succeeds on the superproject PR, add the `run-windows-build` label to the PR (using `gh pr edit --add-label run-windows-build`) to trigger the Windows build, then wait for it to succeed too.
 - If all checks pass, proceed to ask for approval.

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Remove Run Windows Build Label
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1282
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
         with:
           # The token is necessary to be able to remove the label even if the workflow is triggered by a pull request
           # coming from a fork.
@@ -36,7 +36,7 @@ jobs:
             github.event.label.name == 'run-windows-build' ||
             (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build')))
     name: Build and Test Windows - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: root-solution-larger-runners
       machine-types: '["warp-windows-2025-x64-8x"]'
@@ -61,7 +61,7 @@ jobs:
   build-and-test-standard-runners:
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test Windows - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: root-solution-standard-runners
       # Since dev builds are not awaited by anyone, they can run on the slower free runners.
@@ -88,7 +88,7 @@ jobs:
         github.event.label.name == 'run-windows-build' ||
         (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build'))
     name: Build and Test Windows - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: nuget-solution
       machine-types: '["windows-2025"]'
@@ -115,7 +115,7 @@ jobs:
         github.event.label.name == 'run-windows-build' ||
         (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build'))
     name: Lint Assets
-    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@dev
 
   powershell-static-code-analysis:
     if: github.ref_name == github.event.repository.default_branch ||
@@ -132,7 +132,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}
@@ -146,7 +146,7 @@ jobs:
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, asset-lint, powershell-static-code-analysis]
     steps:
       - name: Remove Windows Build Warning Label
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1282
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
         with:
           # The token is necessary to be able to remove the label even if the workflow is triggered by a pull request
           # coming from a fork.

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Remove Run Windows Build Label
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1282
         with:
           # The token is necessary to be able to remove the label even if the workflow is triggered by a pull request
           # coming from a fork.
@@ -36,7 +36,7 @@ jobs:
             github.event.label.name == 'run-windows-build' ||
             (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build')))
     name: Build and Test Windows - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
     with:
       parent-job-name: root-solution-larger-runners
       machine-types: '["warp-windows-2025-x64-8x"]'
@@ -61,7 +61,7 @@ jobs:
   build-and-test-standard-runners:
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test Windows - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
     with:
       parent-job-name: root-solution-standard-runners
       # Since dev builds are not awaited by anyone, they can run on the slower free runners.
@@ -88,7 +88,7 @@ jobs:
         github.event.label.name == 'run-windows-build' ||
         (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build'))
     name: Build and Test Windows - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
     with:
       parent-job-name: nuget-solution
       machine-types: '["windows-2025"]'
@@ -115,7 +115,7 @@ jobs:
         github.event.label.name == 'run-windows-build' ||
         (github.event.review.state == 'APPROVED' && contains(github.event.pull_request.labels.*.name, 'requires-windows-build'))
     name: Lint Assets
-    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@issue/OSOE-1282
 
   powershell-static-code-analysis:
     if: github.ref_name == github.event.repository.default_branch ||
@@ -132,7 +132,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-1282
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}
@@ -146,7 +146,7 @@ jobs:
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, asset-lint, powershell-static-code-analysis]
     steps:
       - name: Remove Windows Build Warning Label
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1282
         with:
           # The token is necessary to be able to remove the label even if the workflow is triggered by a pull request
           # coming from a fork.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
     with:
       parent-job-name: root-solution-larger-runners
       machine-types: '["warp-ubuntu-2404-x64-4x"]'
@@ -31,7 +31,7 @@ jobs:
   build-and-test-standard-runners:
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
     with:
       # Since dev builds are not awaited by anyone, they can run on the slower free runners.
       parent-job-name: root-solution-standard-runners
@@ -50,7 +50,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
     with:
       parent-job-name: nuget-solution
       build-directory: NuGetTest
@@ -63,11 +63,11 @@ jobs:
 
   codespell:
     name: Codespell
-    uses: Lombiq/GitHub-Actions/.github/workflows/codespell.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/codespell.yml@issue/OSOE-1282
 
   asset-lint:
     name: Lint Assets
-    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@issue/OSOE-1282
 
   powershell-static-code-analysis:
     name: PowerShell Static Code Analysis
@@ -77,7 +77,7 @@ jobs:
 
   yaml-linting:
     name: YAML Linting
-    uses: Lombiq/GitHub-Actions/.github/workflows/yaml-lint.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/yaml-lint.yml@issue/OSOE-1282
     with:
       config-file-path: tools/Lombiq.GitHub.Actions/.trunk/configs/.yamllint.yaml
       search-path: .
@@ -86,7 +86,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, codespell, asset-lint, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-1282
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}
@@ -100,7 +100,7 @@ jobs:
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     steps:
       - name: Add Windows Build Warning Label
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1282
         with:
           # The token is necessary to be able to add the label even if the workflow is triggered by a pull request
           # coming from a fork.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-test-larger-runners:
     if: github.ref_name != github.event.repository.default_branch
     name: Build and Test - root solution (larger runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: root-solution-larger-runners
       machine-types: '["warp-ubuntu-2404-x64-4x"]'
@@ -31,7 +31,7 @@ jobs:
   build-and-test-standard-runners:
     if: github.ref_name == github.event.repository.default_branch
     name: Build and Test - root solution (standard runners)
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       # Since dev builds are not awaited by anyone, they can run on the slower free runners.
       parent-job-name: root-solution-standard-runners
@@ -50,7 +50,7 @@ jobs:
 
   build-and-test-nuget-test:
     name: Build and Test - NuGetTest solution
-    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/build-and-test-orchard-core.yml@dev
     with:
       parent-job-name: nuget-solution
       build-directory: NuGetTest
@@ -63,11 +63,11 @@ jobs:
 
   codespell:
     name: Codespell
-    uses: Lombiq/GitHub-Actions/.github/workflows/codespell.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/codespell.yml@dev
 
   asset-lint:
     name: Lint Assets
-    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/asset-lint.yml@dev
 
   powershell-static-code-analysis:
     name: PowerShell Static Code Analysis
@@ -77,7 +77,7 @@ jobs:
 
   yaml-linting:
     name: YAML Linting
-    uses: Lombiq/GitHub-Actions/.github/workflows/yaml-lint.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/yaml-lint.yml@dev
     with:
       config-file-path: tools/Lombiq.GitHub.Actions/.trunk/configs/.yamllint.yaml
       search-path: .
@@ -86,7 +86,7 @@ jobs:
     name: Post Pull Request Checks Automation
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, codespell, asset-lint, powershell-static-code-analysis]
     if: github.event.pull_request != ''
-    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/post-pull-request-checks-automation.yml@dev
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}
@@ -100,7 +100,7 @@ jobs:
     needs: [build-and-test-larger-runners, build-and-test-nuget-test, powershell-static-code-analysis]
     steps:
       - name: Add Windows Build Warning Label
-        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@issue/OSOE-1282
+        uses: Lombiq/GitHub-Actions/.github/actions/add-remove-label@dev
         with:
           # The token is necessary to be able to add the label even if the workflow is triggered by a pull request
           # coming from a fork.

--- a/.github/workflows/create-jira-issues-for-community-activities.yml
+++ b/.github/workflows/create-jira-issues-for-community-activities.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-jira-issues-for-community-activities:
     name: Create Jira issues for community activities
-    uses: Lombiq/GitHub-Actions/.github/workflows/create-jira-issues-for-community-activities.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/create-jira-issues-for-community-activities.yml@issue/OSOE-1282
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/create-jira-issues-for-community-activities.yml
+++ b/.github/workflows/create-jira-issues-for-community-activities.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-jira-issues-for-community-activities:
     name: Create Jira issues for community activities
-    uses: Lombiq/GitHub-Actions/.github/workflows/create-jira-issues-for-community-activities.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/create-jira-issues-for-community-activities.yml@dev
     secrets:
       JIRA_BASE_URL: ${{ secrets.DEFAULT_JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.DEFAULT_JIRA_USER_EMAIL }}

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   validate-pull-request:
     name: Validate Pull Request
-    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@issue/OSOE-1282
+    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@dev

--- a/.github/workflows/validate-pull-request.yml
+++ b/.github/workflows/validate-pull-request.yml
@@ -8,4 +8,4 @@ on:
 jobs:
   validate-pull-request:
     name: Validate Pull Request
-    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/validate-pull-request.yml@issue/OSOE-1282


### PR DESCRIPTION
Integrates Renovate dependency updates for OSOE-1282.

## Submodule changes

- **Lombiq.EInvoiceValidator**: client-side library updates via \enovate/non-breaking-dependency-versions\
- **Lombiq.Analyzers**: Meziantou.Analyzer 3.0.85 → 3.0.94
- **Lombiq.GitHub.Actions**: Elasticsearch 9.4.1 → 9.4.2 (SHA pin), lock-file maintenance
- **Lombiq.Hosting.MediaTheme**: deploy workflow digest update

Jira: [OSOE-1282](https://lombiq.atlassian.net/browse/OSOE-1282)

[OSOE-1282]: https://lombiq.atlassian.net/browse/OSOE-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ