### PR TITLE
OSOE-1302: Fixing that event metadata and tags are dropped by the proxy in Lombiq.Marketing

### DIFF
--- a/NuGetTest/Directory.Packages.props
+++ b/NuGetTest/Directory.Packages.props
@@ -58,10 +58,10 @@
     <PackageVersion Include="Lombiq.JsonEditor.Tests.UI" Version="10.0.0" />
     <PackageVersion Include="Lombiq.LoginAsAnybody" Version="6.0.0" />
     <PackageVersion Include="Lombiq.LoginAsAnybody.Tests.UI" Version="6.0.0" />
-    <PackageVersion Include="Lombiq.Marketing" Version="1.0.0" />
-    <PackageVersion Include="Lombiq.Marketing.Pirsch" Version="1.0.0" />
-    <PackageVersion Include="Lombiq.Marketing.UrlShortener" Version="1.0.0" />
-    <PackageVersion Include="Lombiq.Marketing.Tests.UI" Version="1.0.0" />
+    <PackageVersion Include="Lombiq.Marketing" Version="1.0.1" />
+    <PackageVersion Include="Lombiq.Marketing.Pirsch" Version="1.0.1" />
+    <PackageVersion Include="Lombiq.Marketing.UrlShortener" Version="1.0.1" />
+    <PackageVersion Include="Lombiq.Marketing.Tests.UI" Version="1.0.1" />
     <PackageVersion Include="Lombiq.Npm.Targets" Version="1.5.3" />
     <PackageVersion Include="Lombiq.OrchardCoreApiClient.Tests.UI" Version="8.0.0" />
     <PackageVersion Include="Lombiq.Privacy" Version="11.0.0" />


### PR DESCRIPTION
[OSOE-1302](https://lombiq.atlassian.net/browse/OSOE-1302)

[OSOE-1302]: https://lombiq.atlassian.net/browse/OSOE-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ