### PR TITLE
VSIX-109: Fix build errors for Visual Studio extensions in Lombiq.Analyzers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,10 +14,10 @@
     <NuGetBuild>true</NuGetBuild>
   </PropertyGroup>-->
 
-  <!-- Uncomment this to run .NET static code analyzers during rebuilds.
-  <PropertyGroup>
+  <!--Uncomment this to run .NET static code analyzers during rebuilds.-->
+  <!--<PropertyGroup>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
-  </PropertyGroup> -->
+  </PropertyGroup>-->
 
   <Import Project="tools/Lombiq.Analyzers/Lombiq.Analyzers.OrchardCore/Build.props" />
 


### PR DESCRIPTION
[VSIX-109](https://lombiq.atlassian.net/browse/VSIX-109)

[VSIX-109]: https://lombiq.atlassian.net/browse/VSIX-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ